### PR TITLE
Restrict the GraphiQL browser to the development environment.

### DIFF
--- a/lib/zero_phoenix_web/router.ex
+++ b/lib/zero_phoenix_web/router.ex
@@ -8,7 +8,7 @@ defmodule ZeroPhoenixWeb.Router do
   scope "/" do
     pipe_through :api
 
-    if Mix.env() in [:dev, :test] do
+    if Mix.env() == :dev do
       forward "/graphiql",
         Absinthe.Plug.GraphiQL,
         schema: ZeroPhoenixWeb.Graphql.Schema,


### PR DESCRIPTION
This PR supports the following features:

- restrict GraphiQL browser to the development environment