### PR TITLE
Update to Erlang 27.1 and Elixir 1.17.3.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Update the VARIANT arg in docker-compose.yml to pick an Elixir version: 1.9, 1.10, 1.10.4
-ARG VARIANT="1.17.2"
+ARG VARIANT="1.17.3"
 FROM elixir:${VARIANT}
 
 # This Dockerfile adds a non-root user with sudo access. Update the “remoteUser” property in

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
       args:
         # Elixir Version: 1.9, 1.10, 1.10.4, ...
-        VARIANT: '1.17.2'
+        VARIANT: '1.17.3'
         # Phoenix Version: 1.4.17, 1.5.4, ...
         PHOENIX_VERSION: '1.7.14'
         # Node Version: 12, 14, ...
@@ -22,7 +22,7 @@ services:
     command: sleep infinity
 
   db:
-    image: postgres:16.3-bullseye
+    image: postgres:16.4-bullseye
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17.2-otp-27
-erlang 27.0.1
+elixir 1.17.3-otp-27
+erlang 27.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,9 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.15.4-erlang-26.0.2-debian-bullseye-20230612-slim
 #
-
-ARG ELIXIR_VERSION=1.17.2
-ARG OTP_VERSION=27.0.1
-ARG DEBIAN_VERSION=bullseye-20240701-slim
+ARG ELIXIR_VERSION=1.17.3
+ARG OTP_VERSION=27.1
+ARG DEBIAN_VERSION=bullseye-20240904-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The purpose of this example is to provide details as to how one would go about u
 
 ## Software requirements
 
-- Elixir 1.17.2 or newer
+- Elixir 1.17.3 or newer
 
-- Erlang 27.0.1 or newer
+- Erlang 27.1 or newer
 
 - Phoenix 1.7.14 or newer
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ZeroPhoenix.Mixfile do
     [
       app: :zero_phoenix,
       version: "3.6.0",
-      elixir: "~> 1.17.2",
+      elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
This PR supports the following features:

- update to Erlang 27.1

- update to Elixir 1.17.3

- update docs